### PR TITLE
ci: activate DeepSource Elixir analyzer and exclude JS vendor files

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -24,7 +24,7 @@ name = "elixir"
 enabled = true
 
   [analyzers.meta]
-  runtime_version = "1.18"
+  runtime_version = "1.16"
 
 [[analyzers]]
 name = "test-coverage"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,7 +4,8 @@ exclude_patterns = [
     "_build/**",
     "deps/**",
     "priv/static/**",
-    "cover/**"
+    "cover/**",
+    "assets/vendor/**"
 ]
 
 test_patterns = [
@@ -17,6 +18,13 @@ enabled = true
 
   [analyzers.meta]
   environment = ["browser", "nodejs"]
+
+[[analyzers]]
+name = "elixir"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "1.18"
 
 [[analyzers]]
 name = "test-coverage"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -23,9 +23,6 @@ enabled = true
 name = "elixir"
 enabled = true
 
-  [analyzers.meta]
-  runtime_version = "1.16"
-
 [[analyzers]]
 name = "test-coverage"
 enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -20,9 +20,5 @@ enabled = true
   environment = ["browser", "nodejs"]
 
 [[analyzers]]
-name = "test-coverage"
-enabled = true
-
-[[analyzers]]
 name = "secrets"
 enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -20,10 +20,6 @@ enabled = true
   environment = ["browser", "nodejs"]
 
 [[analyzers]]
-name = "elixir"
-enabled = true
-
-[[analyzers]]
 name = "test-coverage"
 enabled = true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,6 @@ jobs:
     - name: Run tests with coverage
       run: mix test --cover
 
-    - name: Report coverage to DeepSource
-      uses: deepsourcelabs/test-coverage-action@master
-      with:
-        key: elixir
-        coverage-file: cover/lcov.info
-        dsn: ${{ secrets.DEEPSOURCE_DSN }}
-
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:


### PR DESCRIPTION
This PR activates the DeepSource Elixir analyzer (v1.18) and excludes the 'assets/vendor' directory from JavaScript analysis to eliminate false positives from third-party libraries.