### PR TITLE
fix: resolve SonarQube quality gate failures (coverage)

### DIFF
--- a/lib/cash_lens_web/live/transaction_live/import_modal_component.ex
+++ b/lib/cash_lens_web/live/transaction_live/import_modal_component.ex
@@ -38,13 +38,7 @@ defmodule CashLensWeb.TransactionLive.ImportModalComponent do
         send(self(), {:import_error, "No file selected."})
         {:noreply, socket}
 
-      results ->
-        file_paths =
-          Enum.map(results, fn
-            {:ok, path} -> path
-            path when is_binary(path) -> path
-          end)
-
+      file_paths ->
         start_bulk_import(account, {:files, file_paths})
         {:noreply, socket}
     end

--- a/test/cash_lens/parsers/csv_parser_test.exs
+++ b/test/cash_lens/parsers/csv_parser_test.exs
@@ -168,5 +168,12 @@ defmodule CashLens.CSVParserTest do
       transactions = CSVParser.parse(csv_content, :bb)
       assert List.first(transactions).description == ""
     end
+
+    test "handles 2-digit year in slashed date format" do
+      csv_content = "Data,Dep,Term,Hist,Doc,Valor,\n01/01/26,0,0,DESCRIPTION,1,-10.00,\n"
+      transactions = CSVParser.parse(csv_content, :bb)
+      assert length(transactions) == 1
+      assert List.first(transactions).date == ~D[2026-01-01]
+    end
   end
 end

--- a/test/cash_lens/parsers/ingestor_test.exs
+++ b/test/cash_lens/parsers/ingestor_test.exs
@@ -152,4 +152,46 @@ defmodule CashLens.Parsers.IngestorTest do
       assert tx.description == "M\u00E1-formado"
     end
   end
+
+  describe "import_directory/2" do
+    import CashLens.AccountsFixtures
+
+    setup do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "ingestor_test_#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+      on_exit(fn -> File.rm_rf(tmp_dir) end)
+      {:ok, tmp_dir: tmp_dir}
+    end
+
+    test "imports all supported files from a directory", %{tmp_dir: tmp_dir} do
+      account = account_fixture(parser_type: "bb_csv")
+      File.cp!(@bb_sample, Path.join(tmp_dir, "sample.csv"))
+
+      assert {:ok, 3} = Ingestor.import_directory(account, tmp_dir)
+    end
+
+    test "returns error for a non-directory path" do
+      account = account_fixture(parser_type: "bb_csv")
+
+      assert {:error, "Path is not a directory"} =
+               Ingestor.import_directory(account, "/nonexistent/path")
+    end
+
+    test "skips unsupported file types", %{tmp_dir: tmp_dir} do
+      account = account_fixture(parser_type: "bb_csv")
+      File.write!(Path.join(tmp_dir, "readme.txt"), "ignored")
+
+      assert {:ok, 0} = Ingestor.import_directory(account, tmp_dir)
+    end
+
+    test "returns error summary when files fail to import", %{tmp_dir: tmp_dir} do
+      account = account_fixture(parser_type: "unknown_parser")
+      File.write!(Path.join(tmp_dir, "file.csv"), "Data,Dep,Term,Hist,Doc,Valor,\n")
+
+      assert {:error, msg} = Ingestor.import_directory(account, tmp_dir)
+      assert msg =~ "files failed to import"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **`ingestor.ex`**: Add 4 tests for the previously untested `import_directory/2` function, covering: happy path, non-directory path error, unsupported file type filtering, and the `summarize_results` error branch
- **`csv_parser.ex`**: Add test for `normalize_year/1` with a 2-digit year (the `y < 100` guard clause), triggered by dates like `01/01/26`
- **`import_modal_component.ex`**: Remove dead `{:ok, path} -> path` clause — `consume_uploaded_entries/3` already unwraps `{:ok, val}` before returning, so results are always plain binary paths

## Test plan

- [ ] All 324 existing tests pass (`mix test`)
- [ ] No Credo issues (`mix credo --strict`)
- [ ] SonarQube quality gate passes on new code coverage (was 95.4%, needs 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)