### PR TITLE
fix: reimbursement — auto-mark toggle and total-to-receive calculation

### DIFF
--- a/lib/cash_lens/transactions.ex
+++ b/lib/cash_lens/transactions.ex
@@ -4,6 +4,7 @@ defmodule CashLens.Transactions do
   """
 
   import Ecto.Query, warn: false
+  alias CashLens.Categories.Category
   alias CashLens.Repo
   alias CashLens.Transactions.AutoCategorizer
   alias CashLens.Transactions.BulkIgnorePattern
@@ -418,8 +419,20 @@ defmodule CashLens.Transactions do
   def update_transaction_category(id, category_id) do
     transaction = get_transaction!(id)
 
+    extra =
+      case category_id && Repo.get(Category, category_id) do
+        %Category{default_reimbursable: true} when is_nil(transaction.reimbursement_status) ->
+          %{reimbursement_status: "pending"}
+
+        _ ->
+          %{}
+      end
+
     transaction
-    |> Ecto.Changeset.cast(%{category_id: category_id}, [:category_id])
+    |> Ecto.Changeset.cast(Map.merge(%{category_id: category_id}, extra), [
+      :category_id,
+      :reimbursement_status
+    ])
     |> Ecto.Changeset.foreign_key_constraint(:category_id)
     |> Repo.update()
   end

--- a/lib/cash_lens_web/live/reimbursement_live/index.ex
+++ b/lib/cash_lens_web/live/reimbursement_live/index.ex
@@ -41,9 +41,9 @@ defmodule CashLensWeb.ReimbursementLive.Index do
         <div class="card bg-base-100 shadow-sm border border-base-300">
           <div class="card-body p-6">
             <h2 class="text-xs font-black uppercase opacity-40 mb-1">Total to Receive</h2>
-            <p class="text-3xl font-black text-primary">{format_currency(@total_pending)}</p>
+            <p class="text-3xl font-black text-primary">{format_currency(@total_to_receive)}</p>
             <p class="text-[10px] opacity-50 font-bold uppercase mt-2">
-              {@pending_count} expenses waiting
+              {@pending_count} pending + {@requested_count} requested
             </p>
           </div>
         </div>
@@ -454,6 +454,8 @@ defmodule CashLensWeb.ReimbursementLive.Index do
     total_requested =
       Enum.reduce(requested, Decimal.new("0"), &Decimal.add(&2, &1.amount)) |> Decimal.abs()
 
+    total_to_receive = Decimal.add(total_pending, total_requested)
+
     total_recovered =
       Enum.reduce(paid, Decimal.new("0"), fn tx, acc ->
         if Decimal.gt?(tx.amount, 0), do: Decimal.add(acc, tx.amount), else: acc
@@ -464,6 +466,7 @@ defmodule CashLensWeb.ReimbursementLive.Index do
     |> assign(:paid_groups, paid_groups)
     |> assign(:total_pending, total_pending)
     |> assign(:total_requested, total_requested)
+    |> assign(:total_to_receive, total_to_receive)
     |> assign(:pending_count, length(pending))
     |> assign(:requested_count, length(requested))
     |> assign(:total_recovered_month, total_recovered)


### PR DESCRIPTION
## Summary

- `update_transaction_category` now respects `default_reimbursable` on the assigned category: if the category has the flag set and the transaction has no reimbursement status, it is automatically set to `"pending"`
- "Total to Receive" card now displays `pending + requested` instead of `pending` only

## Test plan

- [x] `mix quality_check` passes (362 tests, 0 failures)
- [x] Assigning a `default_reimbursable` category inline marks the transaction as pending
- [x] "Total to Receive" reflects the full outstanding amount across both statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)