### PR TITLE
feat: category display — full hierarchy path and root-first ordering

### DIFF
--- a/lib/cash_lens/categories.ex
+++ b/lib/cash_lens/categories.ex
@@ -20,8 +20,8 @@ defmodule CashLens.Categories do
   def list_categories do
     from(c in Category,
       left_join: p in assoc(c, :parent),
-      order_by: [asc: coalesce(p.name, c.name), asc: c.name],
-      preload: [:parent]
+      order_by: [asc: coalesce(p.name, c.name), asc_nulls_first: c.parent_id, asc: c.name],
+      preload: [parent: :parent]
     )
     |> Repo.all()
   end

--- a/lib/cash_lens/categories/category.ex
+++ b/lib/cash_lens/categories/category.ex
@@ -55,8 +55,8 @@ defmodule CashLens.Categories.Category do
   @doc """
   Returns a display name in the format 'Parent > Child'
   """
-  def full_name(%__MODULE__{name: name, parent: %__MODULE__{name: parent_name}}),
-    do: "#{parent_name} > #{name}"
+  def full_name(%__MODULE__{name: name, parent: %__MODULE__{} = parent}),
+    do: "#{full_name(parent)} > #{name}"
 
   def full_name(%__MODULE__{name: name}), do: name
   def full_name(_), do: ""


### PR DESCRIPTION
## Summary

- `list_categories` sort order changed from `(coalesce(p.name, c.name), c.name)` to `(coalesce(p.name, c.name), parent_id NULLS FIRST, c.name)` — root categories now always appear before their children (previously children with names alphabetically before the parent would sort first)
- `Category.full_name/1` is now recursive: builds full paths like `Casa > Manutenção > Sofá` for any depth; `list_categories` preload deepened to `[parent: :parent]` to support 2-level deep paths

## Test plan

- [x] `mix quality_check` passes (362 tests, 0 failures)
- [x] Root categories appear before children in lists and dropdowns
- [x] Category path shows full ancestry (not just immediate parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)